### PR TITLE
Fix vertical scaling

### DIFF
--- a/R/plot.pedigree.R
+++ b/R/plot.pedigree.R
@@ -146,13 +146,13 @@ plot.pedigree <- function(x, id = x$id, status = x$status,
 
     boxsize <- symbolsize* min(ht1, ht2, stemp1, wd2) # box size in inches
     hscale <- (psize[1]- boxsize)/diff(xrange)  #horizontal scale from user-> inch
-    vscale <- (psize[2]-(stemp3 + stemp2/2 + boxsize))/ max(1, maxlev-1)
+    vscale <- (psize[2]-(stemp3 + stemp2 + boxsize))/ max(1, maxlev-1)
     boxw  <- boxsize/hscale  # box width in user units
     boxh  <- boxsize/vscale   # box height in user units
     labh  <- stemp2/vscale   # height of a text string
     legh  <- min(1/4, boxh  *1.5)  # how tall are the 'legs' up from a child
-    par(usr=c(xrange[1]- boxw/2, xrange[2]+ boxw/2, 
-              maxlev+ boxh+ stemp3 + stemp2/2 , 1))
+    par(usr=c(xrange[1]- boxw/2, xrange[2]+ boxw/2,
+              maxlev+ boxh+ stemp3/vscale + stemp2/vscale , 1))
     ## Doc: end of sizing
     ## Doc: Sizing
     ## Doc:  subsection: drawbox


### PR DESCRIPTION
Hi,

This PR modifies 2 lines of `plot.pedigree()`, fixing a minor bug affecting the vertical scaling. The problem is most visible when plotting small pedigrees with multiline labels:

``` r
library(kinship2, quietly = TRUE)

# Simple trio with multiline labels
x = pedigree(1:3, dadid = c(0,0,1), momid = c(0,0,2), sex = c(1,2,1))
id = c("1", "2", "3\n1/1\n1/1\n1/1\n1/1\n1/1\n1/1")

# Plot
par(mar = c(2,2,2,2))
plot(x, id = id)

# Show plot region
box("figure")
box("plot", lty = 2)    
```

![](https://i.imgur.com/BDSRRX9.png)

<sup>Created on 2022-09-15 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

As seen, the symbols are vertically squished, and the pedigree does not fill the plot region. This is caused by the following line in the source code, where the `usr` parameter is set:
https://github.com/mayoverse/kinship2/blob/0a0dbd3d0d6096f42c77f6c432d8a1cb0f51dc52/R/plot.pedigree.R#L154-L155
In the third entry, `maxlev` and `boxh` are correctly given in user coordinates, but the `stemp3` and `stemp2` terms are not -- they should be divided by `vscale`. 

Furthermore, I believe that `vscale` is slightly miscalculated:
https://github.com/mayoverse/kinship2/blob/0a0dbd3d0d6096f42c77f6c432d8a1cb0f51dc52/R/plot.pedigree.R#L149

As I understand it, the term `stemp2/2` (both here and in the `usr` vector) is meant to account for the vertical gap between the symbol and the label. But this gap is actually `stemp2 * 0.7` (i.e., `labh * 0.7` after scaling):
https://github.com/mayoverse/kinship2/blob/0a0dbd3d0d6096f42c77f6c432d8a1cb0f51dc52/R/plot.pedigree.R#L271

Thus, the factor 1/2 is too small, sometimes allowing the label to go below the plot region. I suggest to simply remove it, which ensures a tiny amount of white space below the label.

Here is the same example plotted with the suggested changes:
``` r
devtools::install_github("magnusdv/kinship2", ref = "fix-scaling", quiet = TRUE)
library(kinship2, quietly = TRUE)

plot(x, id = id)

# Show plot region
box("figure")
box("plot", lty = 2)    
```

![](https://i.imgur.com/AiIcDhe.png)

<sup>Created on 2022-09-15 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

Thanks for maintaining this useful package!
Magnus