### PR TITLE
Bug ped shrink correction

### DIFF
--- a/R/findAvailAffected.R
+++ b/R/findAvailAffected.R
@@ -64,8 +64,7 @@ findAvailAffected <- function(ped, avail, affstatus)
 
   # trim by subject with min bits. This trims fewer subject than
   # using max(bits).
-
-  idTrim <- trimDat[bits==min(bits), 1]
+  idTrim <- trimDat[, 1][bits == min(bits)]
 
   ## break ties by random choice
   if(length(idTrim) > 1)

--- a/R/pedigree.shrink.R
+++ b/R/pedigree.shrink.R
@@ -68,7 +68,7 @@ pedigree.shrink <- function(ped, avail, affected=NULL, maxBits = 16) {
     pedTrimmed <- pedigree.trim(idTrimUnavail, ped)
     avail <- avail[match(pedTrimmed$id, ped$id)]
     idTrimmed <- c(idTrimmed, idTrimUnavail)
-    idList$unavail <- paste(idTrimUnavail, collapse=' ')
+    idList$unavail <- idTrimUnavail
 
   } else {
   ## no trimming, reset to original ped
@@ -95,8 +95,7 @@ pedigree.shrink <- function(ped, avail, affected=NULL, maxBits = 16) {
       pedNew <- pedigree.trim(idTrimNonInform, pedTrimmed)
       avail <- avail[match(pedNew$id, pedTrimmed$id)]
       idTrimmed <- c(idTrimmed, idTrimNonInform)
-      idList$noninform = paste(c(idList$noninform, 
-                                 idTrimNonInform), collapse=' ')
+      idList$noninform = c(idList$noninform, idTrimNonInform)
       pedTrimmed <- pedNew
 
     }
@@ -146,8 +145,7 @@ pedigree.shrink <- function(ped, avail, affected=NULL, maxBits = 16) {
       bitSize <- save$bitSize
       bitVec <- c(bitVec, bitSize)
       idTrimmed <- c(idTrimmed, save$idTrimmed)
-      idList$affect = paste(c(idList$affect, save$idTrimmed),
-                            collapse=' ')
+      idList$affect = c(idList$affect, save$idTrimmed)
     }
 
 


### PR DESCRIPTION
Here are small change that set idTrimmed as a vector of id.
With that all the test are consistent and pass.
The problem was coming from findUnvailable where sometimes gave a vector and sometimes a named matrix.

We should now be able to add github action for each PR / push.